### PR TITLE
fix: screenNumberPerside

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-tab-panel",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Tabbar component for Rax.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/src/BaseView.js
+++ b/src/BaseView.js
@@ -43,7 +43,7 @@ class BaseView extends Component {
     let {screenNumbersPerSide} = this.props;
     let {itemCount, curIndex} = this;
     let visibleIndexes = [];
-    if (screenNumbersPerSide >= 0) {
+    if (screenNumbersPerSide === 0 || screenNumbersPerSide > 0) {
       let max = curIndex + screenNumbersPerSide > itemCount - 1 ? itemCount - 1 : curIndex + screenNumbersPerSide;
       let min = curIndex - screenNumbersPerSide < 0 ? 0 : curIndex - screenNumbersPerSide;
       for (let i = min; i < curIndex; i++) {


### PR DESCRIPTION
fix judge for screenNumberPerside, which initial value is null, but was judged a number.